### PR TITLE
Fixing for call to arms and adding some config enhancements

### DIFF
--- a/QuickConnect/Properties/AssemblyInfo.cs
+++ b/QuickConnect/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/QuickConnect/src/Mod.cs
+++ b/QuickConnect/src/Mod.cs
@@ -5,7 +5,7 @@ using HarmonyLib;
 
 namespace QuickConnect
 {
-    [BepInPlugin("net.bdew.valheim.QuickConnect", "QuickConnect", "1.6.0")]
+    [BepInPlugin("net.bdew.valheim.QuickConnect", "QuickConnect", "1.6.1")]
     class Mod : BaseUnityPlugin
     {
         public static ManualLogSource Log;
@@ -16,6 +16,8 @@ namespace QuickConnect
         public static ConfigEntry<int> labelFontSize;
         public static ConfigEntry<int> windowWidth;
         public static ConfigEntry<int> windowHeight;
+        public static ConfigEntry<bool> customConnectionError;
+        public static ConfigEntry<string> customDelimiter;
 
         void Awake()
         {
@@ -26,6 +28,14 @@ namespace QuickConnect
             labelFontSize = Config.Bind("UI", "LabelFontSize", 0);
             windowWidth = Config.Bind("UI", "WindowWidth", 250);
             windowHeight = Config.Bind("UI", "WindowHeight", 50);
+            customConnectionError = Config.Bind("UI", "CustomConnectionError", false, "Show custom connection failure message in addition to vanilla connection failure message.");
+            customDelimiter = Config.Bind("UI", "CustomDelimiter", "", "Override server config delimiter. Defaults to a colon (':').");
+            Config.SettingChanged += (s, e) =>
+            {
+                Servers.Init();
+                QuickConnectUI.instance.redraw = true;
+            };
+
             var harmony = new Harmony("net.bdew.valheim.QuickConnect");
             harmony.PatchAll();
         }

--- a/QuickConnect/src/PatchCharacterBack.cs
+++ b/QuickConnect/src/PatchCharacterBack.cs
@@ -1,5 +1,4 @@
 ﻿using HarmonyLib;
-using UnityEngine;
 
 namespace QuickConnect
 {
@@ -8,10 +7,7 @@ namespace QuickConnect
     {
         static void Postfix()
         {
-            if (QuickConnectUI.instance)
-            {
-                QuickConnectUI.instance.AbortConnect();
-            }
+            QuickConnectUI.instance.AbortConnect();
         }
     }
 }

--- a/QuickConnect/src/PatchCharacterStart.cs
+++ b/QuickConnect/src/PatchCharacterStart.cs
@@ -1,0 +1,14 @@
+﻿using HarmonyLib;
+using UnityEngine;
+
+namespace QuickConnect
+{
+    [HarmonyPatch(typeof(FejdStartup), "OnCharacterStart")]
+    class PatchCharacterStart
+    {
+        static void Postfix()
+        {
+            GameObject.Destroy(QuickConnectUI.instance);
+        }
+    }
+}

--- a/QuickConnect/src/PatchConnectFailed.cs
+++ b/QuickConnect/src/PatchConnectFailed.cs
@@ -2,13 +2,15 @@
 
 namespace QuickConnect
 {
-    [HarmonyPatch(typeof(ZSteamMatchmaking), "OnJoinServerFailed")]
+    [HarmonyPatch(typeof(ZNet), "OnDestroy")]
     class PatchConnectFailed
     {
         static void Postfix()
         {
-            if (QuickConnectUI.instance)
+            if (Mod.customConnectionError.Value && ZNet.GetConnectionStatus() == ZNet.ConnectionStatus.ErrorConnectFailed)
+            {
                 QuickConnectUI.instance.JoinServerFailed();
+            }
         }
     }
 }

--- a/QuickConnect/src/PatchPasswordPrompt.cs
+++ b/QuickConnect/src/PatchPasswordPrompt.cs
@@ -8,7 +8,7 @@ namespace QuickConnect
     {
         static bool Prefix(ZNet __instance, ZRpc rpc, bool needPassword, string serverPasswordSalt)
         {
-            string currentPass = QuickConnectUI.instance.CurrentPass();
+            string currentPass = QuickConnectUI.CurrentPass();
             if (currentPass != null)
             {
                 if (needPassword)
@@ -19,6 +19,7 @@ namespace QuickConnect
                     saltField.SetValue(null, serverPasswordSalt);
                     MethodInfo sendPeerMethod = typeof(ZNet).GetMethod("SendPeerInfo", BindingFlags.NonPublic | BindingFlags.Instance);
                     sendPeerMethod.Invoke(__instance, new object[] { rpc, currentPass });
+                    QuickConnectUI.connecting = null;
                     return false;
                 }
                 Mod.Log.LogInfo("Server didn't want password?");

--- a/QuickConnect/src/PatchUiInit.cs
+++ b/QuickConnect/src/PatchUiInit.cs
@@ -1,5 +1,4 @@
 ﻿using HarmonyLib;
-using UnityEngine;
 
 namespace QuickConnect
 {
@@ -8,12 +7,7 @@ namespace QuickConnect
     {
         static void Postfix()
         {
-            if (!QuickConnectUI.instance)
-            {
-                Servers.Init();
-                var go = new GameObject("QuickConnect");
-                QuickConnectUI.instance = go.AddComponent<QuickConnectUI>();
-            }
+            QuickConnectUI.instance.GetInstanceID();
         }
     }
 }

--- a/QuickConnect/src/Servers.cs
+++ b/QuickConnect/src/Servers.cs
@@ -18,7 +18,7 @@ namespace QuickConnect
 
             public override string ToString()
             {
-                return string.Format("Server(name={0},ip={1},port={2}}", name, ip, port);
+                return string.Format("Server(name={0},ip={1},port={2})", name, ip, port);
             }
         }
 
@@ -29,6 +29,8 @@ namespace QuickConnect
             entries.Clear();
             try
             {
+                var delimiter = Mod.customDelimiter.Value.Equals(String.Empty) ? ':' : Mod.customDelimiter.Value[0];
+
                 if (File.Exists(ConfigPath))
                 {
                     using (var file = new StreamReader(ConfigPath))
@@ -38,7 +40,7 @@ namespace QuickConnect
                         {
                             line = line.Trim();
                             if (line.Length == 0 || line.StartsWith("#")) continue;
-                            var split = line.Split(':');
+                            var split = line.Split(delimiter);
                             if (split.Length >= 3)
                             {
                                 var aName = split[0];
@@ -57,7 +59,7 @@ namespace QuickConnect
                             }
                             else
                             {
-                                Mod.Log.LogWarning("Invalid config line: " + line);
+                                Mod.Log.LogDebug("Invalid config line: " + line);
                             }
                         }
                         Mod.Log.LogInfo(string.Format("Loaded {0} server entries", entries.Count));
@@ -67,6 +69,7 @@ namespace QuickConnect
             catch (Exception ex)
             {
                 Mod.Log.LogError(string.Format("Error loading config {0}", ex));
+                QuickConnectUI.instance.ShowError("Error loading server config");
             }
         }
     }


### PR DESCRIPTION
In the Call to Arms update (0.221.4), the server list logic was redone. This resulted in the `OnJoinServerFailed` method being removed from `ZSteamMatchmaking`. There is a custom error toast in QuickConnect that depended on that method. It seems like that toast may have been broken for a while, but the method was still there in the Valheim code so the plugin continued to work.

This PR fixes the issue by patching to `ZNet` `OnDestroy` in lieu of the now missing method. The following enhancements have also been made:

- Configuration changes made via the https://github.com/BepInEx/BepInEx.ConfigurationManager are now dynamically applied. Previously, the game needed to be restarted or you needed to join a server, and then log out, to see the configuration changes take effect.
- Added a `Reload from Disk` button to reload the server config. The server config file can be edited outside of Valheim in your text editor of choice, or it can be edited from within Valheim using the file editor in the https://github.com/BepInEx/BepInEx.ConfigurationManager
- A configuration toggle for the custom error toast mentioned above was added, and it defaults to disabled.
- A configuration option to specify a custom delimiter to override the `:` delimiter was added. If this option is used, the colon between the IP address and the port will also have to match the custom delimiter setting. This is probably not particularly useful, but I added it when I was exploring adding IPv6 support. I stopped when I discovered that the Valheim dedicated server does not support IPv6.